### PR TITLE
Update version number to correspond with text number change APGT-718

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Applegate",
   "author": "Applegate",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{


### PR DESCRIPTION
The version number must be incremented in order to update the theme on Zendesk.